### PR TITLE
补充对模块系统、模块文件的说明

### DIFF
--- a/docs/users/software/01-lmod.md
+++ b/docs/users/software/01-lmod.md
@@ -3,8 +3,8 @@ id: lmod
 title: Lmod - 使用集群上的软件
 ---
 
-[Lmod](https://github.com/TACC/Lmod) 是一个环境变量管理软件，是基于 Lua 的 Environment Module System 实现。
-在其他超算系统上，使用的通常是另一个[基于 Tcl 的 Environment Module System](https://github.com/cea-hpc/modules)。
+[Lmod](https://github.com/TACC/Lmod) 是一个环境变量管理软件，是基于 Lua 的*模块系统（Module System，或 Environment Module System）* 实现。
+在其他超算系统上，使用的通常是另一个基于 Tcl 的实现：[Environment Modules](https://github.com/cea-hpc/modules)。
 
 通过 Lmod，用户可以:
 - 切换不同软件，如 Anaconda 和 Python；
@@ -13,8 +13,12 @@ title: Lmod - 使用集群上的软件
 当用户想要使用软件时，只要运行相应命令来加载软件的环境变量即可。Lmod 提供了 `module`和`ml`命令供用户选择，让用户能够用命令来加载、卸载、查找已安装的软件。
 
 :::caution
-目前，实验室的集群已经用 Lmod 代替了以前的基于 Tcl 的 Environment Module System。
-使用旧的 Module System 的用户请参考[Tcl旧模块的处理](#Tcl旧模块的处理)。
+目前，实验室的集群已经用 Lmod 代替了以前的 Environment Modules。
+使用旧模块系统的用户请参考 [Tcl 旧模块的处理](#Tcl旧模块的处理)。
+:::
+
+:::note
+为了方便叙述，在本节中我们把 Lmod 和 Environment Modules 两种实现统称为模块系统，并将 Environment Modules 简称为 Modules。
 :::
 
 ## 常用命令
@@ -41,7 +45,7 @@ $ ml -GCC               # 卸载软件的环境变量
 ```
 
 :::info 初始环境变量
-如果不加载软件，用户使用的就是系统自带的软件，例如， GCC 可能使用的就是 /usr/bin 下面的 GCC 4.8.5，Python 可能使用的是 /usr/bin 下面的 Python 2.7.5。
+如果不加载软件，用户使用的就是系统自带的软件，例如， GCC 可能使用的就是 `/usr/bin` 下面的 GCC 4.8.5，Python 可能使用的是 `/usr/bin` 下面的 Python 2.7.5。
 :::
 
 ## 快速入门
@@ -71,11 +75,11 @@ $ ml -GCC/8.2.0                 # module unload GCC/8.2.0
 $ ml -GCC/8.2.0 GCC/7.3.0       # module swap
 ```
 
-Lmod有两个查询命令：`module avail` 和 `module spider`，Tcl版本只有 `module avail`。区别如下：
+Lmod 有两个查询命令：`module avail` 和 `module spider`，Environment Modules 只有 `module avail`。区别如下：
 
 - `module avail` (Lmod)：查询**当前**可加载的软件包。如果一个软件包需要一些依赖项，在依赖项被加载之前它可能不会显示在列表里。
 - `module spider` (Lmod)：查询**所有**可加载的软件包。
-- `module avail` (Tcl)：查询**所有**可加载的软件包。
+- `module avail` (Modules)：查询**所有**可加载的软件包。
 
 :::tip Shell的配置
 目前默认的配置是 bash，如果需要使用其他 shell 加载模块，可以在 Lmod 目录下找相应的配置脚本，或联系管理员解决。
@@ -206,7 +210,7 @@ The following have been reloaded with a version change:
 - ***...reloaded with a version change***：模块被重新加载为不同版本。这是由于这些模块在两个GCC版本下都存在，但版本和路径都不同。
 
 :::tip ml 和 module swap
-基于Tcl的模块系统只能用 `module swap` 或 `module switch` 切换软件包的版本，但 Lmod 还可以使用 `ml` 命令完成切换。
+`ml` 存在于 Lmod 和 Modules v4.5 中，在 Modules v4.5 以前只能用 `module swap` 或 `module switch` 切换软件包的版本。
 :::
 
 ## 默认模块
@@ -406,8 +410,8 @@ $ module use $HOME/modulefiles
 
 ### 编写模块文件
 
-一个modulefile中最主要的就是各种环境变量，例如 `PATH` 和 `LIBRARY_PATH`。
-用户使用 `module load` 加载这个modulefile时，实际上就是在当前shell设置这些环境变量。
+一个 modulefile 中最主要的就是各种环境变量，例如 `PATH` 和 `LIBRARY_PATH`。
+用户使用 `module load` 加载这个 modulefile 时，实际上就是在当前 shell 设置这些环境变量。
 因此，用户在安装完软件后，通常需要把 `bin`、`include`、`lib` 等目录的绝对路径写在 modulefile 中。
 
 自定义模块文件时，可以用命令查看集群上已有模块的配置文件供参考，例如，查看 `GCC/8.2.0` 的模块文件：
@@ -419,10 +423,10 @@ $ module show GCC/8.2.0-2.31.1
 
 ## Tcl 旧模块的处理
 
-Environment Module System 的迁移（指从 Tcl 模块系统迁移到 Lua 的模块系统）并不影响 Tcl 旧的软件模块的使用，
-因为 lmod 同样兼容 Tcl 模块文件。
+模块系统的迁移（指从 Environment Modules 迁移到 Lmod）并不影响 Tcl 旧的软件模块的使用，
+因为 Lmod 同样兼容 Tcl 模块文件。
 
-目前，实验室集群上 Tcl 旧的模块都转移到另一个路径了，因此无法直接用 `module avail` 命令看到。如果要使用旧的模块，请执行：
+目前，实验室集群上的 Tcl 模块都转移到另一个路径了，因此无法直接用 `module avail` 命令看到。如果要使用旧的模块，请执行：
 
 ```bash
 $ ml showlegacy
@@ -431,5 +435,5 @@ $ ml showlegacy
 旧模块提供的软件安装在 `/opt` 下，新模块提供的软件安装在 `/apps` 下。
 
 :::note 冲突的模块
-为防止模块冲突，在 `/opt` 中安装编译工具、科学计算软件Tcl模块时尽量不要与 Lmod 模块同名（如 GCC、OpenMPI、MPICH、PETSc等）。除此之外，其他手动安装的软件都可随意使用。
+为防止模块冲突，在 `/opt` 中安装编译工具、科学计算软件 Tcl 模块时尽量不要与 Lua 模块同名（如 GCC、OpenMPI、MPICH、PETSc 等）。除此之外，其他手动安装的软件都可随意使用。
 :::

--- a/docs/users/software/01-lmod.md
+++ b/docs/users/software/01-lmod.md
@@ -118,7 +118,7 @@ $ module avail
 GCC/8.2.0-2.31.1
 
 ## 加载GCC后再次查看模块列表，OpenMPI已经可以加载
-$ module GCC/8.2.0-2.31.1
+$ module load GCC/8.2.0-2.31.1
 $ module avail
 
 GCC/8.2.0-2.31.1 (L)    OpenMPI/3.1.3
@@ -131,7 +131,7 @@ GCC/8.2.0-2.31.1 (L)    OpenMPI/3.1.3
 $ module purge
 
 ## 跳过GCC，直接加载OpenMPI
-$ module OpenMPI/3.1.3
+$ module load OpenMPI/3.1.3
 
 Lmod has detected the following error: These module(s) exist but cannot be loaded as requested:
 "OpenMPI/3.1.3"
@@ -172,18 +172,18 @@ OpenMPI: OpenMPI/3.1.3
 
 ```bash
 ## 使用OpenMPI之前必须加载GCC/8.2.0，否则报错
-## ml OpenMPI/3.1.3
-$ ml GCC/8.2.0-2.31.1 OpenMPI/3.1.3
+## module load OpenMPI/3.1.3
+$ module load GCC/8.2.0-2.31.1 OpenMPI/3.1.3
 
 ## 成功加载OpenMPI/3.1.3后，切换到OpenMPI/4.0.0
-$ ml OpenMPI/4.0.0
+$ module load OpenMPI/4.0.0
 
 The following have been reloaded with a version change:
   1) OpenMPI/3.1.3 => OpenMPI/4.0.0     2) hwloc/1.11.11 => hwloc/2.0.2
 
 ## 在加载了GCC/8.2.0和OpenMPI/3.1.3的情况下，切换到GCC/9.1.0
 ## 此时OpenMPI会进入inactive状态
-$ ml GCC/9.1.0-2.32
+$ module load GCC/9.1.0-2.32
 
 Inactive Modules:
   1) OpenMPI/4.0.0     2) hwloc/2.0.2     3) libxml2/2.9.8
@@ -218,9 +218,9 @@ $ module -d avail
 例如，在实验室集群上，以下两条命令的效果是相同的：
 
 ```bash
-$ ml GCC/8.2.0-2.31.1
+$ module load GCC/8.2.0-2.31.1
 
-$ ml GCC
+$ module load GCC
 ```
 
 默认模块可以由*模块名*目录下的配置文件 `.modulerc.lua` 或 `.modulerc` 指定。例如，以下命令可以指定 GCC 的默认版本为 8.3.0：
@@ -261,11 +261,11 @@ $ module load gompi
 
 ```bash
 ## 加载gompi
-$ ml purge
-$ ml gompi/2019a
+$ module purge
+$ module load gompi/2019a
 
 ## 查看当前加载的模块
-$ ml
+$ module list
 Currently loaded Modules:
   1) GCCcore/8.2.0      4) zlib/1.2.11      7) libxml2/2.9.8        10) OpenMPI/3.1.3
   2) binutils/2.31.1    5) numactl/2.0.12   8) libciaccess/0.14     11) gompi/2019a
@@ -275,7 +275,7 @@ Currently loaded Modules:
 或者检查 modulefile 中的 `depends_on` 语句：
 
 ```bash
-$ ml show gompi/2019a |& grep depends_on
+$ module show gompi/2019a |& grep depends_on
 
 depends_on("GCC/8.2.0-2.31.1")
 depends_on("OpenMPI/3.1.3")
@@ -290,9 +290,9 @@ depends_on("OpenMPI/3.1.3")
 
 ```bash
 ## 从当前shell卸载整个工具链
-$ ml -gompi/2019a
+$ module unload gompi/2019a
 
-$ ml
+$ module list
 No modules loaded
 ```
 
@@ -302,10 +302,10 @@ No modules loaded
 
 ```bash
 ## 加载gompi
-$ ml gompi/2019a
+$ module load gompi/2019a
 
 ## 切换到gmpich
-$ ml -gompi/2019a gmpich/2019a
+$ module swap gompi/2019a gmpich/2019a
 ```
 
 常用的工具链见集群文档的公共软件列表。
@@ -317,26 +317,26 @@ $ ml -gompi/2019a gmpich/2019a
 
 ```bash
 ## 加载一些模块
-$ ml CMake/3.19.1 GCC/8.2.0-2.31-1 OpenMPI/3.1.3
+$ module load CMake/3.19.1 GCC/8.2.0-2.31-1 OpenMPI/3.1.3
 
 ## 保存到名为devtools的列表
-$ ml save devtools
+$ module save devtools
 
 Saved current collection of modules to: "devtools"
 
 ## 查看所有已保存的配置
-$ ml savelist
+$ module savelist
 Named collection list:
   1) devtools
 
 ## 清空当前环境，加载之前保存的配置
-$ ml purge
-$ ml restore devtools
+$ module purge
+$ module restore devtools
 
 Restoring modules from user's devtools
 
 ## 弃用一个已保存的加载配置
-$ ml disable devtools
+$ module disable devtools
 ```
 
 ## 自定义软件和模块

--- a/docs/users/software/01-lmod.md
+++ b/docs/users/software/01-lmod.md
@@ -69,8 +69,8 @@ $ ml -GCC/8.2.0 GCC/7.3.0       # module swap
 多数情况下使用 Lmod 切换模块都不需要卸载之前的模块，例如，
 
 ```bash
-$ ml GCC/7.3.0
-$ ml GCC/8.2.0
+$ module load GCC/7.3.0
+$ module load GCC/8.2.0
 ```
 
 执行第二条命令会自动切换相应的依赖项。
@@ -83,6 +83,14 @@ Lmod 有两个查询命令：`module avail` 和 `module spider`，Environment Mo
 - `module avail` (Lmod)：查询**当前**可加载的软件包。如果一个软件包需要一些依赖项，在依赖项被加载之前它可能不会显示在列表里。
 - `module spider` (Lmod)：查询**所有**可加载的软件包。
 - `module avail` (Modules)：查询**所有**可加载的软件包。
+
+### `module` 与 `ml`
+
+`ml` 实际上是 Lmod 中的一个脚本，它像 `spack` 一样给用户提供便利的功能。Modules 从 4.5 开始也引入了 `ml`。
+
+Lmod：https://lmod.readthedocs.io/en/latest/010_user.html#ml-a-convenient-tool
+
+Modules：https://modules.readthedocs.io/en/latest/ml.html
 
 ## 模块层次
 
@@ -192,10 +200,6 @@ The following have been reloaded with a version change:
 - ***...have been reloaded***：模块被重新加载。这是由于 `libpciaccess/0.14` 这些软件包在两个GCC版本下都存在，但安装路径不同。
 
 - ***...reloaded with a version change***：模块被重新加载为不同版本。这是由于这些模块在两个GCC版本下都存在，但版本和路径都不同。
-
-:::tip ml 和 module swap
-`ml` 存在于 Lmod 和 Modules v4.5 中，在 Modules v4.5 以前只能用 `module swap` 或 `module switch` 切换软件包的版本。
-:::
 
 ## 默认模块
 

--- a/docs/users/software/01-lmod.md
+++ b/docs/users/software/01-lmod.md
@@ -7,8 +7,10 @@ title: Lmod - 使用集群上的软件
 在其他超算系统上，使用的通常是另一个基于 Tcl 的实现：[Environment Modules](https://github.com/cea-hpc/modules)。
 
 通过 Lmod，用户可以:
-- 切换不同软件，如 Anaconda 和 Python；
-- 切换同一软件的不同版本，如 GCC 7.3.0 和 GCC 8.2.0。
+
+- 加载/卸载软件；
+- 切换软件，如 Anaconda 和 Python；
+- 切换软件版本，如 GCC 7.3.0 和 GCC 8.2.0。
 
 当用户想要使用软件时，只要运行相应命令来加载软件的环境变量即可。Lmod 提供了 `module`和`ml`命令供用户选择，让用户能够用命令来加载、卸载、查找已安装的软件。
 
@@ -19,33 +21,6 @@ title: Lmod - 使用集群上的软件
 
 :::note
 为了方便叙述，在本节中我们把 Lmod 和 Environment Modules 两种实现统称为模块系统，并将 Environment Modules 简称为 Modules。
-:::
-
-## 常用命令
-
-常用的用于查询、加载等功能的命令如下：
-
-```bash
-$ module avail              # 查看当前可加载的软件
-$ module spider             # 查看/搜索集群上所有可加载的软件
-$ module load GCC           # 加载某个软件(如GCC)的环境变量
-$ module list               # 查看已加载的软件
-$ module unload GCC         # 卸载某个软件(如GCC)的环境变量
-$ module pruge              # 清除所有已经加载等环境变量
-```
-
-或者，使用简化的命令：
-
-```bash
-$ ml av                 # 查看当前可加载的软件
-$ ml spider             # 查看集群上所有可加载的软件
-$ ml GCC                # 加载软件的环境变量
-$ ml                    # 查看已加载的软件
-$ ml -GCC               # 卸载软件的环境变量
-```
-
-:::info 初始环境变量
-如果不加载软件，用户使用的就是系统自带的软件，例如， GCC 可能使用的就是 `/usr/bin` 下面的 GCC 4.8.5，Python 可能使用的是 `/usr/bin` 下面的 Python 2.7.5。
 :::
 
 ## 快速入门
@@ -67,19 +42,24 @@ $ module save mymods            # 保存已加载的模块到列表中
 $ module savelist               # 查看已保存的加载方案
 $ module restore mymods         # 恢复已保存的加载方案
 
+$ module purge                  # 卸载所有已加载的模块
+
 $ ml                            # module命令的前端，单独调用相当于 module list
-$ ml av                         # module avail
+$ ml avail                      # module avail
 $ ml spider                     # module spider
 $ ml GCC/8.2.0                  # module load GCC/8.2.0
 $ ml -GCC/8.2.0                 # module unload GCC/8.2.0
 $ ml -GCC/8.2.0 GCC/7.3.0       # module swap
 ```
 
-Lmod 有两个查询命令：`module avail` 和 `module spider`，Environment Modules 只有 `module avail`。区别如下：
+更多关于 Lmod 的用法，可参考官方文档：
 
-- `module avail` (Lmod)：查询**当前**可加载的软件包。如果一个软件包需要一些依赖项，在依赖项被加载之前它可能不会显示在列表里。
-- `module spider` (Lmod)：查询**所有**可加载的软件包。
-- `module avail` (Modules)：查询**所有**可加载的软件包。
+- [Lmod: A New Environment Module System](https://lmod.readthedocs.io/en/latest/index.html)
+- [User Guide for Lmod](https://lmod.readthedocs.io/en/latest/010_user.html)
+
+:::info 初始环境变量
+如果不加载软件，用户使用的就是系统自带的软件，例如， GCC 可能使用的就是 `/usr/bin` 下面的 GCC 4.8.5，Python 可能使用的是 `/usr/bin` 下面的 Python 2.7.5。
+:::
 
 :::tip Shell的配置
 目前默认的配置是 bash，如果需要使用其他 shell 加载模块，可以在 Lmod 目录下找相应的配置脚本，或联系管理员解决。
@@ -96,9 +76,13 @@ $ ml GCC/8.2.0
 执行第二条命令会自动切换相应的依赖项。
 :::
 
-更多关于 Lmod 的用法，可参考官方文档：
-- [Lmod: A New Environment Module System](https://lmod.readthedocs.io/en/latest/index.html)
-- [User Guide for Lmod](https://lmod.readthedocs.io/en/latest/010_user.html)
+### `module avail` 与 `module spider`
+
+Lmod 有两个查询命令：`module avail` 和 `module spider`，Environment Modules 只有 `module avail`。区别如下：
+
+- `module avail` (Lmod)：查询**当前**可加载的软件包。如果一个软件包需要一些依赖项，在依赖项被加载之前它可能不会显示在列表里。
+- `module spider` (Lmod)：查询**所有**可加载的软件包。
+- `module avail` (Modules)：查询**所有**可加载的软件包。
 
 ## 模块层次
 

--- a/docs/users/software/01-lmod.md
+++ b/docs/users/software/01-lmod.md
@@ -30,13 +30,15 @@ $ man module                    # manpage
 $ module help                   # help
 
 $ module avail                  # 查看当前可加载的模块（软件）
+$ module avail GCC				# 查看当前可加载的包含'GCC'的模块
 $ module spider                 # 查看所有可加载的模块（软件）
 $ module spider GCC             # 查看GCC有多少不同版本已安装在集群上
-$ module spider GCC/8.2.0       # 查看模块的依赖关系
+$ module spider GCC/8.2.0       # 查看必须手动加载的依赖
+$ module keyword GCC            # 在模块名称和描述中查找关键字
+
 $ module load GCC/8.2.0         # 加载模块，从而能使用GCC/8.2.0
 $ module list                   # 列出已加载的模块
 $ module unload GCC/8.2.0       # 卸载模块
-$ module key GCC                # 在模块名称和描述中查找关键字
 
 $ module save mymods            # 保存已加载的模块到列表中
 $ module savelist               # 查看已保存的加载方案

--- a/docs/users/software/01-spack.md
+++ b/docs/users/software/01-spack.md
@@ -55,6 +55,22 @@ $ spack unload -a
 最简单的办法就是在 `source` 之前，用 `env` 检查一下自己的环境，从 `PATH` 里去掉 Spack 路径，并删除 Spack 定义的函数。
 :::
 
+### Rosetta Stone：从 `module` 到 `spack`
+
+|                | Module System                                                | Spack                                                        |
+| -------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| 查询可用软件   | `module avail`<br />`module avail CMake`<br />`module spider` | `spack find`<br />`spack find cmake`                         |
+| 列出已加载软件 | `module list`                                                | `spack find --loaded`                                        |
+| 加载软件       | `module load CMake/3.19`<br />`module add CMake/3.19`        | `spack load cmake@3.19`                                      |
+| 卸载软件       | `module unload CMake/3.19`<br />`module rm CMake/3.19`       | `spack unload cmake@3.19`                                    |
+| 清空已加载软件 | `module purge`                                               | `spack unload -a`                                            |
+| 仅加载依赖项   | 无                                                           | `spack load --only dependencies cmake@3.19`                  |
+| 切换版本       | `module swap CMake/3.19 CMake/3.18`                          | 无，先卸载再加载                                             |
+| 查看说明       | `module help CMake/3.19`                                     | `spack info cmake`                                           |
+| 查看配置文件   | `module show CMake/3.19`                                     | `spack edit cmake`                                           |
+| 查看安装路径   | `module show CMake/3.19`                                     | `spack location -i cmake@3.19`<br />`spack find --paths cmake@3.19` |
+| 查看依赖关系   | 逐个查看配置文件                                             | `spack find -d cmake@3.19`<br />`spack dependencies -i cmake@3.19`<br />`spack dependents -i cmake@3.19` |
+
 ## 基本概念
 在使用 Spack 之前，建议先熟悉 Spack 中的相关概念，如包的命名规则。
 

--- a/docs/users/software/01-spack.md
+++ b/docs/users/software/01-spack.md
@@ -602,8 +602,9 @@ $ spack load --only dependencies petsc
 
 相关命令：
 
-- `spack config`
-- `spack install`
+- `spack config`：操作配置文件
+- `spack install`：安装软件包
+- `spack external find`：搜索可用的外部软件包
 
 Spack：
 
@@ -645,6 +646,15 @@ $ spack load boost@1.70.0-system
 
 - `prefix`：给定搜索路径，也就是前面的例子演示的；
 - `modules`：给定加载的模块，当系统上有模块系统时可以直接利用已有模块。
+
+### 搜索外部软件包
+
+当我们不清楚软件包的具体位置时，可以用命令来搜索外部软件包，不过这种方式需要软件包的配置文件提供可供搜索的内容（Spack v0.16.0 只支持搜索可执行文件）。
+
+```bash
+# 搜索系统已有的openmpi软件包
+$ spack external find openmpi
+```
 
 ### 外部软件包的依赖
 

--- a/docs/users/software/01-spack.md
+++ b/docs/users/software/01-spack.md
@@ -454,15 +454,16 @@ packages.yaml
   2   all:
   3     target: [x86_64]
 
-# 添加集群的软件包 repo。编辑配置文件，修改为如下两行
+# 添加集群的软件包 repo。编辑配置文件，增加两项
 $ spack config edit repos
 
 repos.yaml
   1 repos:
-  2   - /apps/spack_repo
+  2   - /apps/repos/spack/hpcde
+  3   - /apps/repos/spack/flipped
 
 # 检查 repos
-$ spack config get repos
+$ spack repo list
 
 # 编辑配置文件，添加镜像位置
 $ spack config edit mirrors
@@ -831,7 +832,7 @@ Spack 安装的软件默认使用 RPATH（可关闭），实验室集群上的�
 
 - Spack 的 git 仓库，从官网下载或直接从实验室集群上拷贝均可；
 - 实验室集群的 Spack mirror，位于 `/apps/sources/spack`；
-- 实验室集群的 Spack repo，位于 `/apps/spack_repo`。
+- 实验室集群的 Spack repo，位于 `/apps/repos/spack`。
 
 拷贝数据到超算后，参考实验室集群文档中关于 Spack 的说明、公共 Spack 的配置（`config.yaml`、`packages.yaml` 等配置文件）来配置用户级 Spack，然后使用 Spack 安装软件即可。如果需要安装的软件在集群的 Spack mirror 中没有源代码，用户可以自行下载。
 
@@ -844,6 +845,12 @@ $ spack config --scope site get config
 # 查看config.yaml文件
 $ spack config --scope site edit config
 ```
+
+:::tip Spack repos
+实验室集群上可能有多个自定义 packages 的 Spack repos，它们属于不同的名字空间。其中，有一部分在 GitHub 上维护，其余仅在实验室集群上可见。
+
+`namespace hpcde`：https://github.com/hpcde/spack-repos
+:::
 
 ### `externals`
 

--- a/docs/users/software/01-spack.md
+++ b/docs/users/software/01-spack.md
@@ -492,6 +492,12 @@ $ spack find
 - 解决方法三：在配置文件 [packages.yaml](https://spack.readthedocs.io/en/latest/build_settings.html#build-settings) 中设置某个版本为优先。
 :::
 
+:::tip Fortran 编译器
+有的软件包可能会强制要求 Fortran 编译器（与 Spack 版本有关），而 `llvm` 是没有 Fortran 编译器的。遇到这种情况时，暂时的解决办法如下：
+- 打开 `compilers.yaml`，找到 `clang` 对象；
+- 修改其中的 `f77` 和 `fc` 值为可用的 Fortran 编译器路径，例如 `gfortran` 路径。
+:::
+
 ## 安装/删除软件包
 
 参考：

--- a/docs/users/software/01-spack.md
+++ b/docs/users/software/01-spack.md
@@ -69,7 +69,7 @@ $ spack unload -a
 | 查看说明       | `module help CMake/3.19`                                     | `spack info cmake`                                           |
 | 查看配置文件   | `module show CMake/3.19`                                     | `spack edit cmake`                                           |
 | 查看安装路径   | `module show CMake/3.19`                                     | `spack location -i cmake@3.19`<br />`spack find --paths cmake@3.19` |
-| 查看依赖关系   | 逐个查看配置文件                                             | `spack find -d cmake@3.19`<br />`spack dependencies -i cmake@3.19`<br />`spack dependents -i cmake@3.19` |
+| 查看依赖关系   | 查看手动加载的依赖<br />`module spider CMake/3.19`<br />查看可自动加载的依赖<br />`module show CMake/3.19` | `spack find -d cmake@3.19`<br />`spack dependencies -i cmake@3.19`<br />`spack dependents -i cmake@3.19` |
 
 ## 基本概念
 在使用 Spack 之前，建议先熟悉 Spack 中的相关概念，如包的命名规则。


### PR DESCRIPTION
Spack对模块文件的支持在原文档中描述太少。在超算上难以避免使用模块，且加载模块比加载Spack软件包要快得多。因此有必要对模块文件的相关内容多作一些说明，让用户能够自行用Spack来操作模块文件。

- [x] 统一模块系统相关术语，如 Module System
- [x] 调整Spack章节的顺序，将需要写权限的内容后移
- [x] 补充说明Spack如何操作模块文件，给出必要链接
- [x] 补充说明在超算上如何配置Spack，补充注意事项
- [x] 补充`module`命令与`spack`命令的简单对应关系，便于用户迁移